### PR TITLE
refactor: remove `simple-jwt` in gradle settings

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,7 +24,6 @@ include(
     "guid",
     "key-pair-loader",
     "num4j",
-    "simple-jwt",
     "simple-jwt-facade",
     "simple-jwt-authzero",
     "simple-jwt-spring-boot-starter",


### PR DESCRIPTION
This pull request removes the `simple-jwt` module declared in `settings.gradle.kts`.